### PR TITLE
Receive data from browser

### DIFF
--- a/HTML Demo 2.0.3/ws.html
+++ b/HTML Demo 2.0.3/ws.html
@@ -77,7 +77,7 @@
       var scheme = document.getElementById('scheme').value;		
       var host = document.getElementById('host').value;
       var port = document.getElementById('port').value;
-      socket = new WebSocket(scheme + host + ':' + port + "/path/to/file.php?data=1", ['proto1', 'proto2']);
+      socket = new WebSocket(scheme + host + ':' + port + "/path/to/file.php?data=1", ['proto2']);
       socket.binaryType = 'arraybuffer';
       socket.onopen = function (event) 
       {
@@ -147,7 +147,7 @@
     <option value="10.0.0.1">10.0.0.1</option> 
     <option value="81.0.231.149">81.0.231.149</option>
   </select> 
-  <input type="number" id="port" value="81" step="1" /> 
+  <input type="number" id="port" value="8080" step="1" /> 
 </p> 
 <p> 
   <button id="open">Open</button> 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # bauglir-websocket 2
 
+(Fork of Robert-112's repo, might separate code bases if there's no response to my PRs or issue reports.)
+
 Funktionsfähige Kopie der WebSocket-Bibliothek von Bauglir
 (Original: https://code.google.com/archive/p/bauglir-websocket/)
 


### PR DESCRIPTION
Hi. New browsers like Chrome and Firefox send data to winsocket connection with compressed by  "permessage-deflate" rfc7692. Decompress at server not easy! But can simple disable compression as well:
add answer handshake header  'Compression: None'
and skip header 'Sec-WebSocket-Extensions: ' with any extensions.